### PR TITLE
Load seed classes through PSR-4 rather than classmap.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "app/"
+            "App\\": "app/",
+            "": "database/seeds"
         },
         "classmap": [
-            "database/seeds",
             "database/factories"
         ]
     },


### PR DESCRIPTION
Currently the seed classes are loaded through the `autoloader` entry in `composer.json` using `classmap`. This is done because the classes live in the root (rather than in a namespace.

However, composer supports loading classes with no namespace through PSR-4.

This merge-request changes the composer autoloader entry to be loaded through PSR-4 rather than the classmap.